### PR TITLE
Add requirements.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gaussfit
-Program to fit multiple gausses to data
+Python2 script fitting data to Gauss peaks model
 
 To fit multiple gausses to a data file first one should prepare file with fitting parameters: start values and fitting range.
 Here is an explained example from `data.fit`:
@@ -19,7 +19,7 @@ where `x0` is expectation value, `A` is amplitude, `s` is gauss width.
 Program by default is doing fitting from file 'data.txt' and taking parameters from 'data.fit', to do fitting from any data `datafile` and parameters `parafile`:
 
 ~~~
-python fitgauss.py datafile parafile 
+python fitgauss.py datafile parafile
 ~~~
 
 By third argument user can specify `log` file:
@@ -29,8 +29,3 @@ python fitgauss.py file parafile log
 ~~~
 
 ![GitHub Logo](example.png)
-
-Requirements:
-* `Python 2.7`
-* `SciPy 0.18.1`
-* `Matplotlib 1.3.1` 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+backports-abc==0.5
+certifi==2016.9.26
+cycler==0.10.0
+matplotlib==1.5.3
+nose==1.3.7
+numpy==1.11.2
+pyparsing==2.1.10
+python-dateutil==2.6.0
+pytz==2016.10
+scipy==0.18.1
+singledispatch==3.4.0.3
+six==1.10.0
+tornado==4.4.2


### PR DESCRIPTION
When you use virtualenv and/or [virtualenvwrapper](http://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html) you may want to have a requirements file listing all dependencies. Than you can install them using `pip install -r requirements.txt` command or freeze updated dependencies installed in virtualenv using `pip freeze > requirements.txt` command.

So check if everything is all right.